### PR TITLE
Add Linux packaging script

### DIFF
--- a/scripts/build-debian.sh
+++ b/scripts/build-debian.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Build Rust binary
+pnpm run build-rs
+
+# Build Electron app and create Debian package
+pnpm exec electron-vite build
+pnpm exec electron-builder --linux deb --config electron-builder.config.cjs

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -27,8 +27,12 @@ if (process.platform === "darwin") {
   run(`pnpm build:mac --arm64 --publish always`, {
     cwd: desktopDir,
   })
-} else {
+} else if (process.platform === "win32") {
   run(`pnpm build:win --publish always`, {
+    cwd: desktopDir,
+  })
+} else {
+  run(`pnpm build:linux --publish always`, {
     cwd: desktopDir,
   })
 }

--- a/src/main/keyboard.ts
+++ b/src/main/keyboard.ts
@@ -13,7 +13,7 @@ import path from "path"
 const rdevPath = path
   .join(
     __dirname,
-    `../../resources/bin/whispo-rs${process.env.IS_MAC ? "" : ".exe"}`,
+    `../../resources/bin/whispo-rs${process.platform === "win32" ? ".exe" : ""}`,
   )
   .replace("app.asar", "app.asar.unpacked")
 

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -8,7 +8,16 @@ import {
 } from "./window"
 import { state } from "./state"
 
-const defaultIcon = path.join(__dirname, `../../resources/${process.env.IS_MAC ? 'trayIconTemplate.png' : 'trayIcon.ico'}`)
+const defaultIcon = path.join(
+  __dirname,
+  `../../resources/${
+    process.platform === 'darwin'
+      ? 'trayIconTemplate.png'
+      : process.platform === 'win32'
+        ? 'trayIcon.ico'
+        : 'trayIconTemplate.png'
+  }`
+)
 const stopIcon = path.join(
   __dirname,
   "../../resources/stopTrayIconTemplate.png",


### PR DESCRIPTION
## Summary
- fix OS check for the native binary
- use appropriate tray icon on Linux
- support Linux in release script
- add `scripts/build-debian.sh` to generate `.deb` package

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm build-rs` *(fails: system library `xi` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684867775ccc832a8b1c598284cebaf6